### PR TITLE
Bind to "0.0.0.0" instead of "localhost" 

### DIFF
--- a/main.go
+++ b/main.go
@@ -1085,7 +1085,7 @@ func main() {
 		return nil
 	})
 
-	host := getEnv("HOST", "localhost")
+	host := getEnv("HOST", "0.0.0.0")
 	port := getEnv("PORT", "8080")
 	hostAddress := fmt.Sprintf("%s:%s", host, port)
 


### PR DESCRIPTION
Although you can override the default HOST value, it's better to bind to 0.0.0.0 to simplify running this container on Kubernetes or other PaaS platforms.